### PR TITLE
Dispose JsonDocument properly

### DIFF
--- a/Config.cs
+++ b/Config.cs
@@ -57,7 +57,7 @@ public sealed class Config
 		if (!File.Exists(path))
 			throw new FileNotFoundException($"Cannot find API keys file at {path}. Expected JSON: {{\"DISCORD_TOKEN\":\"...\",\"OPENAI_API_KEY\":\"...\"}}");
 
-		var json = JsonDocument.Parse(File.ReadAllText(path));
+		using var json = JsonDocument.Parse(File.ReadAllText(path));
 		var root = json.RootElement;
 		var discord = root.GetProperty("DISCORD_TOKEN").GetString() ?? "";
 		var openai = root.GetProperty("OPENAI_API_KEY").GetString() ?? "";


### PR DESCRIPTION
## Summary
- ensure JsonDocument is disposed when loading config

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bac0f70c3483299b45d2e732a451b2