### PR TITLE
Handle code fences when splitting Discord messages

### DIFF
--- a/Util/Splitter.cs
+++ b/Util/Splitter.cs
@@ -10,11 +10,21 @@ public static class Splitter
 		while (i < text.Length)
 		{
 			var len = Math.Min(max, text.Length - i);
-			// try not to cut in the middle of code fences/lines
+			// try not to cut in the middle of code fences or lines
 			var slice = text.AsSpan(i, len).ToString();
 			var lastBreak = slice.LastIndexOf('\n');
-			if (lastBreak > 200)
-			{ slice = slice[..lastBreak]; len = lastBreak; }
+			if (lastBreak >= 0)
+			{ len = lastBreak + 1; slice = slice[..len]; }
+			var fences = 0;
+			for (var idx = slice.IndexOf("```", StringComparison.Ordinal); idx >= 0; idx = slice.IndexOf("```", idx + 3, StringComparison.Ordinal))
+				fences++;
+			if (fences % 2 != 0)
+			{
+				var fenceBreak = slice.LastIndexOf("```", StringComparison.Ordinal);
+				var fenceLine = slice.LastIndexOf('\n', fenceBreak - 1);
+				if (fenceLine >= 0)
+				{ len = fenceLine + 1; slice = slice[..len]; }
+			}
 			yield return slice;
 			i += len;
 		}


### PR DESCRIPTION
## Summary
- Trim slices at the last newline regardless of its position
- Avoid cutting through code fences while chunking messages

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bac130edf883298e6e95bbcf0131f8