### PR TITLE
Fix missing responses after approval for ephemeral interactions

### DIFF
--- a/Bot.cs
+++ b/Bot.cs
@@ -218,7 +218,7 @@ public sealed class Bot
 
 	private async Task OnButtonAsync(SocketMessageComponent component)
 	{
-		await component.DeferAsync(); // ack the click; no extra messages
+		await component.DeferAsync(ephemeral: true); // ack the click; no extra messages
 
 		var parts = component.Data.CustomId.Split(':', 2);
 		if (parts.Length != 2)


### PR DESCRIPTION
## Summary
- Ensure button interactions are deferred as ephemeral to avoid failure and allow posting responses

## Testing
- `/root/.dotnet/dotnet format HarmonyBot.sln --include Bot.cs --verbosity diagnostic`
- `/root/.dotnet/dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68bacda69be48329afb9cf954bd43c2d