### PR TITLE
Sort context pages and advance cursor

### DIFF
--- a/Bot.cs
+++ b/Bot.cs
@@ -305,12 +305,17 @@ public sealed class Bot : IDisposable
 
 		while (list.Count < cfg.CtxMaxMessages)
 		{
-			var page = await channel.GetMessagesAsync(cursor!.Value, Direction.After, 100).FlattenAsync();
-			if (!page.Any())
+			var page = (await channel.GetMessagesAsync(cursor!.Value, Direction.After, 100).FlattenAsync())
+					  .OrderBy(m => m.Timestamp)
+					  .ThenBy(m => m.Id)
+					  .ToList();
+			if (page.Count == 0)
 				break;
 
+			IMessage? last = null;
 			foreach (var m in page)
 			{
+				last = m;
 				// hard cap on total span from the anchor
 				if ((m.Timestamp - anchor.Timestamp).TotalSeconds > cfg.GroupMaxDurationSec)
 				{
@@ -345,7 +350,7 @@ public sealed class Bot : IDisposable
 
 			if (cursor is null)
 				break;
-			cursor = page.Last().Id;
+			cursor = last!.Id;
 		}
 
 		return list;


### PR DESCRIPTION
## Summary
- order forward context pages chronologically before running gap and interpost checks
- advance cursor using id of the last processed message

## Testing
- `/root/.dotnet/dotnet format HarmonyBot.sln --include Bot.cs` *(no output)*
- `/root/.dotnet/dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68bc2ec757d48329a3a7a94084a1b89a