### PR TITLE
Honor interpost settings in group collection

### DIFF
--- a/Bot.cs
+++ b/Bot.cs
@@ -330,7 +330,8 @@ public sealed class Bot : IDisposable
 				else
 				{
 					if (!cfg.IncludeInterposts)
-					{ cursor = null; break; }
+						continue; // skip other authors when interposts are excluded
+
 					interposts++;
 					if (interposts > cfg.GroupMaxInterposts)
 					{ cursor = null; break; }
@@ -338,7 +339,7 @@ public sealed class Bot : IDisposable
 				}
 
 				// character budget to avoid over-long prompts
-				var chars = list.Sum(x => (x.Content?.Length ?? 0));
+				var chars = list.Sum(x => x.Content?.Length ?? 0);
 				if (chars >= cfg.CtxMaxChars)
 				{ cursor = null; break; }
 			}


### PR DESCRIPTION
## Summary
- Skip non-author messages when interposts are disabled
- Enforce `GroupMaxInterposts` when interposts are allowed

## Testing
- `dotnet format HarmonyBot.csproj --verbosity diagnostic`
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_68bc2ee480dc8329b2ba40d0d6df309b