### PR TITLE
Expose AI log content settings

### DIFF
--- a/Bot.cs
+++ b/Bot.cs
@@ -40,8 +40,9 @@ public sealed class Bot : IDisposable
 		_loggerFactory = LogSetup.CreateLoggerFactory();
 		_log = _loggerFactory.CreateLogger<Bot>();
 
-		_logAiContent = (Environment.GetEnvironmentVariable("LOG_AI_CONTENT") ?? "truncated").ToLowerInvariant();
-		_logAiContentMax = int.TryParse(Environment.GetEnvironmentVariable("LOG_AI_CONTENT_MAX"), out var n) ? n : 4000;
+
+		_logAiContent = cfg.LogAiContent;
+		_logAiContentMax = cfg.LogAiContentMax;
 
 		_log.LogInformation("Configuration: {configuration}", _cfg.Summary);
 

--- a/Config.cs
+++ b/Config.cs
@@ -26,6 +26,8 @@ public sealed class Config
 	[Configuration] public int CtxMaxMessages { get; init; } = GetEnvInt("CTX_MAX_MESSAGES", 60);
 	[Configuration] public int CtxMaxChars { get; init; } = GetEnvInt("CTX_MAX_CHARS", 20000);
 	[Configuration] public bool IncludeInterposts { get; init; } = GetEnvBool("CTX_INCLUDE_INTERPOSTS", true);
+	[Configuration] public string LogAiContent { get; init; } = GetEnvString("LOG_AI_CONTENT", "full").ToLowerInvariant();
+	[Configuration] public int LogAiContentMax { get; init; } = GetEnvInt("LOG_AI_CONTENT_MAX", 4000);
 
 	public string Summary => string.Join(", ", GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance)
 		.Select(p =>

--- a/README.md
+++ b/README.md
@@ -3,3 +3,10 @@
 ## About
 
 The Discord bot for the official discord support server for the official Lib.Harmony open source project.
+
+## Logging
+
+Two environment variables control how much of the LLM prompt and response are written to the logs:
+
+- `LOG_AI_CONTENT` (default: `full`): `none` suppresses content, `truncated` limits output, and `full` mirrors the API traffic.
+- `LOG_AI_CONTENT_MAX` (default: `4000`): maximum characters when `LOG_AI_CONTENT` is `truncated`.


### PR DESCRIPTION
## Summary
- allow configuring AI log content limits through `Config`
- document `LOG_AI_CONTENT` and `LOG_AI_CONTENT_MAX` env vars

## Testing
- `/root/.dotnet/dotnet format HarmonyBot.sln --verbosity normal --include Bot.cs --include Config.cs --include README.md`
- `/root/.dotnet/dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68bc2ef2abf48329b3e62b351c8be83c