### PR TITLE
Dispose attachment download response

### DIFF
--- a/Bot.cs
+++ b/Bot.cs
@@ -381,7 +381,7 @@ public sealed class Bot : IDisposable
 
 		try
 		{
-			var response = await _httpClient.GetAsync(attachment.Url);
+			using var response = await _httpClient.GetAsync(attachment.Url, HttpCompletionOption.ResponseHeadersRead);
 			if (!response.IsSuccessStatusCode)
 				return $"[{attachment.Filename}: download failed]";
 


### PR DESCRIPTION
## Summary
- dispose HTTP response when downloading attachments
- request only headers before reading attachment content

## Testing
- `/root/.dotnet/dotnet format HarmonyBot.csproj --include Bot.cs --verbosity diagnostic`
- `/root/.dotnet/dotnet build`
- `/root/.dotnet/dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bc335285108329a960001bf42bf1bd